### PR TITLE
Modify the name of the images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,25 +16,25 @@ image-build-operator:
 	docker build \
 		--build-arg ARCH=$(ARCH) \
 		--build-arg TAG=$(TAG) \
-		--tag $(ORG)/hardened-sriov-operator:$(TAG) \
-		--tag $(ORG)/hardened-sriov-operator:$(TAG)-$(ARCH) \
+		--tag $(ORG)/hardened-sriov-network-operator:$(TAG) \
+		--tag $(ORG)/hardened-sriov-network-operator:$(TAG)-$(ARCH) \
 	.
 
 .PHONY: image-push-operator
 image-push-operator:
-	docker push $(ORG)/hardened-sriov-operator:$(TAG)-$(ARCH)
+	docker push $(ORG)/hardened-sriov-network-operator:$(TAG)-$(ARCH)
 
 .PHONY: image-manifest-operator
 image-manifest-operator:
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
-		$(ORG)/hardened-sriov-operator:$(TAG) \
-		$(ORG)/hardened-sriov-operator:$(TAG)-$(ARCH)
+		$(ORG)/hardened-sriov-network-operator:$(TAG) \
+		$(ORG)/hardened-sriov-network-operator:$(TAG)-$(ARCH)
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
-		$(ORG)/hardened-sriov-operator:$(TAG)
+		$(ORG)/hardened-sriov-network-operator:$(TAG)
 
 .PHONY: image-scan-operator
 image-scan-operator:
-	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-sriov-operator:$(TAG)
+	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-sriov-network-operator:$(TAG)
 
 .PHONY: image-build-network-config-daemon
 image-build-network-config-daemon:
@@ -42,23 +42,23 @@ image-build-network-config-daemon:
 		-f Dockerfile.sriov-network-config-daemon \
 		--build-arg ARCH=$(ARCH) \
 		--build-arg TAG=$(TAG) \
-		--tag $(ORG)/hardened-network-config-daemon:$(TAG) \
-		--tag $(ORG)/hardened-network-config-daemon:$(TAG)-$(ARCH) \
+		--tag $(ORG)/hardened-sriov-network-config-daemon:$(TAG) \
+		--tag $(ORG)/hardened-sriov-network-config-daemon:$(TAG)-$(ARCH) \
 	.
 
 .PHONY: image-push-network-config-daemon
 image-push-network-config-daemon:
-	docker push $(ORG)/hardened-network-config-daemon:$(TAG)-$(ARCH)
+	docker push $(ORG)/hardened-sriov-network-config-daemon:$(TAG)-$(ARCH)
 
 .PHONY: image-manifest-network-config-daemon
 image-manifest-network-config-daemon:
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
-		$(ORG)/hardened-network-config-daemon:$(TAG) \
-		$(ORG)/hardened-network-config-daemon:$(TAG)-$(ARCH)
+		$(ORG)/hardened-sriov-network-config-daemon:$(TAG) \
+		$(ORG)/hardened-sriov-network-config-daemon:$(TAG)-$(ARCH)
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
-		$(ORG)/hardened-network-config-daemon:$(TAG)
+		$(ORG)/hardened-sriov-network-config-daemon:$(TAG)
 
 .PHONY: image-scan-network-config-daemon
 image-scan-network-config-daemon:
-	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-network-config-daemon:$(TAG)
+	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-sriov-network-config-daemon:$(TAG)
 


### PR DESCRIPTION
Add sriov to the network-config-daemon image name so that we know what we are talking about

Add network to sriov-network-operator so that it coincides with the upstream project name 

Signed-off-by: Manuel Buil <mbuil@suse.com>