### PR TITLE
Disable drone tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM ${HARDENED_IMAGE} as base-builder
 ARG TAG
 ARG BUILD
 ENV VERSION_OVERRIDE=${TAG}${BUILD}
-RUN git clone --depth 1 https://github.com/k8snetworkplumbingwg/sriov-network-operator \
+RUN git clone https://github.com/k8snetworkplumbingwg/sriov-network-operator \
     && cd sriov-network-operator \ 
     && git checkout ${TAG} \ 
     && make clean

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,10 @@ ORG ?= rancher
 TAG ?= 14bd335c17c1b4c6cb7d37c2972c05cc62cadeeb$(BUILD_META)
 export DOCKER_BUILDKIT?=1
 
-ifneq ($(DRONE_TAG),)
-TAG := $(DRONE_TAG)
-endif
+# Temporarily disable this as Github tags can't be a SHA (too long)
+#ifneq ($(DRONE_TAG),)
+#TAG := $(DRONE_TAG)
+#endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))
 $(error TAG needs to end with build metadata: $(BUILD_META))


### PR DESCRIPTION
When using a SHA instead of an upstream tag, it does not work

Signed-off-by: Manuel Buil <mbuil@suse.com>