### PR TITLE
Update versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ platform:
 steps:
 - name: build
   pull: always
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.17.5b7
   commands:
   - make DRONE_TAG=${DRONE_TAG} image-build-operator
   - make DRONE_TAG=${DRONE_TAG} image-build-network-config-daemon
@@ -20,7 +20,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: publish
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.17.5b7
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - make DRONE_TAG=${DRONE_TAG} image-push-operator image-manifest-operator
@@ -39,7 +39,7 @@ steps:
     - tag
 
 - name: scan
-  image: rancher/hardened-build-base:v1.16.10b7
+  image: rancher/hardened-build-base:v1.17.5b7
   commands:
   - make DRONE_TAG=${DRONE_TAG} image-scan-operator
   - make DRONE_TAG=${DRONE_TAG} image-scan-network-config-daemon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # last commit on 2021-10-06
-ARG TAG="14bd335c17c1b4c6cb7d37c2972c05cc62cadeeb"
+ARG TAG="v1.1.0"
+ARG GOBORING_VERSION=1.17.5
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
 ARG GOBORING_IMAGE=goboring/golang:1.16.7b7
-ARG HARDENED_IMAGE=rancher/hardened-build-base:v1.16.10b7
+ARG HARDENED_IMAGE=rancher/hardened-build-base:v${GOBORING_VERSION}b7
 
 FROM ${HARDENED_IMAGE} as base-builder
 ARG TAG
@@ -22,9 +23,16 @@ RUN cd sriov-network-operator \
 FROM ${GOBORING_IMAGE} as config-daemon-builder
 ARG TAG
 ARG BUILD
+ARG GOBORING_VERSION
+ADD https://go-boringcrypto.storage.googleapis.com/go${GOBORING_VERSION}b7.src.tar.gz /usr/local/boring.tgz
+WORKDIR /usr/local/boring
+RUN tar xzf ../boring.tgz
+WORKDIR /usr/local/boring/go/src
+RUN ./make.bash
 ENV VERSION_OVERRIDE=${TAG}${BUILD}
 ENV GOFLAGS=-trimpath
 COPY --from=base-builder /go/sriov-network-operator /go/sriov-network-operator
+WORKDIR /go
 RUN cd sriov-network-operator \
     && make _build-sriov-network-config-daemon \
     && make plugins

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,12 @@ endif
 BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
 # last commit on 2021-10-06
-TAG ?= 14bd335c17c1b4c6cb7d37c2972c05cc62cadeeb$(BUILD_META)
+TAG ?= v1.1.0$(BUILD_META)
 export DOCKER_BUILDKIT?=1
 
-# Temporarily disable this as Github tags can't be a SHA (too long)
-#ifneq ($(DRONE_TAG),)
-#TAG := $(DRONE_TAG)
-#endif
+ifneq ($(DRONE_TAG),)
+TAG := $(DRONE_TAG)
+endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))
 $(error TAG needs to end with build metadata: $(BUILD_META))


### PR DESCRIPTION
Update versions of:

* base image
* upstream sriov-operator
* used goboring version in goboring/golang. As goboring/golang image is not being updated upstream, we'll consume goboring in the same way as we do it in: https://github.com/rancher/image-build-base/blob/master/Dockerfile.amd64#L7-L12

Signed-off-by: Manuel Buil <mbuil@suse.com>