### PR TITLE
Update sriov operator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # last commit on 2021-10-06
-ARG TAG="v1.1.0"
-ARG GOBORING_VERSION=1.17.5
+ARG TAG="v1.2.0"
+ARG GOBORING_VERSION=1.18.5
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
-ARG GOBORING_IMAGE=goboring/golang:1.16.7b7
 ARG HARDENED_IMAGE=rancher/hardened-build-base:v${GOBORING_VERSION}b7
 
 FROM ${HARDENED_IMAGE} as base-builder
@@ -16,26 +15,14 @@ RUN git clone https://github.com/k8snetworkplumbingwg/sriov-network-operator \
 
 FROM base-builder as builder
 ENV CGO_ENABLED=0
-RUN cd sriov-network-operator \
-    && make _build-manager \
-    && make _build-webhook
-
-FROM ${GOBORING_IMAGE} as config-daemon-builder
 ARG TAG
 ARG BUILD
-ARG GOBORING_VERSION
-ADD https://go-boringcrypto.storage.googleapis.com/go${GOBORING_VERSION}b7.src.tar.gz /usr/local/boring.tgz
-WORKDIR /usr/local/boring
-RUN tar xzf ../boring.tgz
-WORKDIR /usr/local/boring/go/src
-RUN ./make.bash
 ENV VERSION_OVERRIDE=${TAG}${BUILD}
 ENV GOFLAGS=-trimpath
-COPY --from=base-builder /go/sriov-network-operator /go/sriov-network-operator
-WORKDIR /go
 RUN cd sriov-network-operator \
-    && make _build-sriov-network-config-daemon \
-    && make plugins
+    && make _build-manager \
+    && make _build-webhook \
+    && make _build-sriov-network-config-daemon
 
 # Create the config daemon image
 FROM ${UBI_IMAGE} as config-daemon
@@ -45,10 +32,8 @@ RUN microdnf update -y \
     && ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n mstflint ; fi) \
     && microdnf install hwdata $ARCH_DEP_PKGS \
     && microdnf clean all
-COPY --from=config-daemon-builder /go/sriov-network-operator/build/_output/linux/amd64/sriov-network-config-daemon /usr/bin/
-COPY --from=config-daemon-builder /go/sriov-network-operator/build/_output/linux/amd64/plugins /plugins
-COPY --from=config-daemon-builder /go/sriov-network-operator/bindata /bindata
-ENV PLUGINSPATH=/plugins
+COPY --from=builder /go/sriov-network-operator/build/_output/linux/amd64/sriov-network-config-daemon /usr/bin/
+COPY --from=builder /go/sriov-network-operator/bindata /bindata
 ENTRYPOINT ["/usr/bin/sriov-network-config-daemon"]
 
 # Create the webhook image

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ endif
 
 BUILD_META=-build$(shell date +%Y%m%d)
 ORG ?= rancher
-# last commit on 2021-10-06
-TAG ?= v1.1.0$(BUILD_META)
+TAG ?= v1.2.0$(BUILD_META)
 export DOCKER_BUILDKIT?=1
 
 ifneq ($(DRONE_TAG),)


### PR DESCRIPTION
This PR makes several updates:
1 - Updates to the newly released 1.2.0
2 - Updates the hardened image version
3 - Deletes all around plugins as that was finally removed from the code: https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/312

Signed-off-by: Manuel Buil <mbuil@suse.com>