### PR TITLE
Add dependabot label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "kind/dependabot"
     reviewers:
       - "rancher/k3s"
 
@@ -14,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "kind/dependabot"
     reviewers:
       - "rancher/k3s"
 


### PR DESCRIPTION
This adds label "kind/dependabot" to the PRs that dependabot generates.
This contributes to https://github.com/rancher/rke2/issues/4130.
This contributes to https://github.com/rancher/rke2/issues/4165
I tested this by running [the dependabot cli](https://github.com/dependabot/cli) locally:
<details>
  <summary>Test Scenario</summary>

```
{
  "input": {
    "job": {
      "package-manager": "docker",
      "allowed-updates": [
        {
          "update-type": "all"
        }
      ],
      "source": {
        "provider": "github",
        "repo": "matttrach/image-build-sriov-operator",
        "directory": "/",
        "commit": "b4358cf91617a759ebca2e6d193fabea2678bd6e"
      },
      "credentials-metadata": [
        {
          "host": "github.com",
          "type": "git_source"
        }
      ]
    },
    "credentials": [
      {
        "host": "github.com",
        "password": "$LOCAL_GITHUB_ACCESS_TOKEN",
        "type": "git_source",
        "username": "x-access-token"
      }
    ]
  },
  "output": [
    {
      "type": "update_dependency_list",
      "expect": {
        "data": {
          "dependencies": [],
          "dependency_files": [
            "/Dockerfile"
          ]
        }
      }
    },
    {
      "type": "mark_as_processed",
      "expect": {
        "data": {
          "base-commit-sha": "b4358cf91617a759ebca2e6d193fabea2678bd6e"
        }
      }
    }
  ]
}
```

</details>