### PR TITLE
Remove push-manifest from drone and Makefile

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,9 +23,9 @@ steps:
   image: rancher/hardened-build-base:v1.20.4b11
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - make DRONE_TAG=${DRONE_TAG} image-push-operator image-manifest-operator
-  - make DRONE_TAG=${DRONE_TAG} image-push-network-config-daemon image-manifest-network-config-daemon
-  - make DRONE_TAG=${DRONE_TAG} image-push-sriov-network-webhook image-manifest-sriov-network-webhook
+  - make DRONE_TAG=${DRONE_TAG} image-push-operator
+  - make DRONE_TAG=${DRONE_TAG} image-push-network-config-daemon
+  - make DRONE_TAG=${DRONE_TAG} image-push-sriov-network-webhook
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password
@@ -78,9 +78,9 @@ steps:
   image: rancher/hardened-build-base:v1.20.4b11
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - make DRONE_TAG=${DRONE_TAG} image-push-operator image-manifest-operator
-  - make DRONE_TAG=${DRONE_TAG} image-push-network-config-daemon image-manifest-network-config-daemon
-  - make DRONE_TAG=${DRONE_TAG} image-push-sriov-network-webhook image-manifest-sriov-network-webhook
+  - make DRONE_TAG=${DRONE_TAG} image-push-operator
+  - make DRONE_TAG=${DRONE_TAG} image-push-network-config-daemon
+  - make DRONE_TAG=${DRONE_TAG} image-push-sriov-network-webhook
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password

--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,6 @@ image-build-operator:
 image-push-operator:
 	docker push $(ORG)/hardened-sriov-network-operator:$(TAG)-$(ARCH)
 
-.PHONY: image-manifest-operator
-image-manifest-operator:
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
-		$(ORG)/hardened-sriov-network-operator:$(TAG) \
-		$(ORG)/hardened-sriov-network-operator:$(TAG)-$(ARCH)
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
-		$(ORG)/hardened-sriov-network-operator:$(TAG)
-
 .PHONY: image-scan-operator
 image-scan-operator:
 	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-sriov-network-operator:$(TAG)
@@ -69,14 +61,6 @@ image-build-network-config-daemon:
 image-push-network-config-daemon:
 	docker push $(ORG)/hardened-sriov-network-config-daemon:$(TAG)-$(ARCH)
 
-.PHONY: image-manifest-network-config-daemon
-image-manifest-network-config-daemon:
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
-		$(ORG)/hardened-sriov-network-config-daemon:$(TAG) \
-		$(ORG)/hardened-sriov-network-config-daemon:$(TAG)-$(ARCH)
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
-		$(ORG)/hardened-sriov-network-config-daemon:$(TAG)
-
 .PHONY: image-scan-network-config-daemon
 image-scan-network-config-daemon:
 	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-sriov-network-config-daemon:$(TAG)
@@ -97,14 +81,6 @@ image-build-sriov-network-webhook:
 .PHONY: image-push-sriov-network-webhook
 image-push-sriov-network-webhook:
 	docker push $(ORG)/hardened-sriov-network-webhook:$(TAG)-$(ARCH)
-
-.PHONY: image-manifest-sriov-network-webhook
-image-manifest-sriov-network-webhook:
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
-		$(ORG)/hardened-sriov-network-webhook:$(TAG) \
-		$(ORG)/hardened-sriov-network-webhook:$(TAG)-$(ARCH)
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
-		$(ORG)/hardened-sriov-network-webhook:$(TAG)
 
 .PHONY: image-scan-sriov-network-webhook
 image-scan-sriov-network-webhook:


### PR DESCRIPTION
We added the drone pipeline manifest to have a multi-arch image, hence we don't need to push a single-arch manifest anymore