### PR TITLE
Bump to upstream version v1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # last commit on 2021-10-06
-ARG TAG="v1.2.0"
+ARG TAG=v1.3.0
 ARG COMMIT="f2ca88418036a7836ea2c0bd1f648a47774997c4"
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
 ARG GO_IMAGE=rancher/hardened-build-base:v1.22.4b2
@@ -10,7 +10,7 @@ FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.3.0 as xx
 
 
 FROM --platform=$BUILDPLATFORM ${GO_IMAGE} as base
-ARG TAG
+ARG TAG=v1.3.0
 ARG BUILD
 ENV VERSION_OVERRIDE=${TAG}${BUILD}
 # copy xx scripts to your build stage
@@ -23,7 +23,7 @@ RUN set -x && \
 
 FROM base as builder
 ENV CGO_ENABLED=0
-ARG TAG
+ARG TAG=v1.3.0
 ARG BUILD
 ENV VERSION_OVERRIDE=${TAG}${BUILD}
 ENV GOFLAGS=-trimpath

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TAG ?= ${GITHUB_ACTION_TAG}
 export DOCKER_BUILDKIT?=1
 
 ifeq ($(TAG),)
-TAG := v1.2.0$(BUILD_META)
+TAG := v1.3.0$(BUILD_META)
 endif
 
 


### PR DESCRIPTION



<Actions>
    <action id="1eebd83cdf50b6b85f2b9734d8925b1d515c7cf3eb31eadf38a95d63428f28ee">
        <h3>Update upstream version</h3>
        <details id="beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0">
            <summary>Bump Makefile to upstream version v1.3.0</summary>
            <p>1 file(s) updated with &#34;TAG := v1.3.0$$(BUILD_META)&#34;:&#xA;&#x9;* Makefile&#xA;</p>
        </details>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump Dockerfile to upstream version v1.3.0</summary>
            <p>changed lines [2 13 26] of file &#34;/tmp/updatecli/github/rancher/image-build-sriov-operator/Dockerfile&#34;</p>
            <details>
                <summary>v1.3.0</summary>
                <pre>&#xA;Release published on the 2024-06-17 08:14:55 +0000 UTC at the url https://github.com/k8snetworkplumbingwg/sriov-network-operator/releases/tag/v1.3.0&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;* Update CONTRIBUTING doc by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/336&#xD;&#xA;* Wait for writer response on Refresh by @rollandf in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/333&#xD;&#xA;* Skip config if policy not applied yet by @rollandf in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/287&#xD;&#xA;* Update helm chart&#39;s application version to v1.2.0 by @eoghanlawless in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/340&#xD;&#xA;* Add coverage evidence to the project by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/281&#xD;&#xA;* load vhost-net kernel module by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/344&#xD;&#xA;* add support for Intel X557 Family by @relyt0925 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/332&#xD;&#xA;* Makefile: copy generated CRDs to Helm dir by @rollandf in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/339&#xD;&#xA;* Pass imagePullSecrets values to operator components via helm chart by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/334&#xD;&#xA;* Fix unit test by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/346&#xD;&#xA;* Make Operator Config tests more strict by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/330&#xD;&#xA;* Remove duplicated and unused code in plugins by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/341&#xD;&#xA;* Remove `go get &lt;binary&gt;` instances by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/348&#xD;&#xA;* Stick with go &lt;1.19 by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/352&#xD;&#xA;* Set `mod=readonly` when installing binaries by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/351&#xD;&#xA;* lint: fix goconst issues by @rollandf in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/335&#xD;&#xA;* external control plane by @zshi-redhat in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/309&#xD;&#xA;* Add unit tests for `daemon` package by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/273&#xD;&#xA;* Add NVIDIA Mellanox Technologies MT2894 Family Ethernet Controller ConnectX-6 Lx by @wizhaoredhat in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/358&#xD;&#xA;* improve drain check by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/354&#xD;&#xA;* ensure network daemon checks if machineConfigPool resource registered before attempting to pause the MachineConfigPool by @relyt0925 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/350&#xD;&#xA;* Adding support for Octeon DPU family by @navadiaev in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/356&#xD;&#xA;* Add support for BF2 in connectX mode by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/353&#xD;&#xA;* Add NVIDIA ConnectX-7 to supported NICs by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/360&#xD;&#xA;* support graceful node shutdown by @pacevedom in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/363&#xD;&#xA;* config-daemon: fix NM udev path by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/369&#xD;&#xA;* End2End - Pod Security Admission fixes by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/368&#xD;&#xA;* Improve `config-daemon` logging by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/370&#xD;&#xA;* Revert &#34;support graceful node shutdown&#34; by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/374&#xD;&#xA;* improve sriov nic selector in tests by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/373&#xD;&#xA;* Add CodeQL workflow for GitHub code scanning by @lgtm-com in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/375&#xD;&#xA;* Fix machine config update in sriovnetworkpoolconfig_controller by @wizhaoredhat in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/381&#xD;&#xA;* Fix imagePullSecrets rendering by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/364&#xD;&#xA;* Remove sh-specific redirections. by @iancoolidge in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/389&#xD;&#xA;* Update Ginkgo to v2 by @liornoy in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/386&#xD;&#xA;* Bump github.com/coreos/ignition/v2 from 2.13.0 to 2.14.0 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/394&#xD;&#xA;* pass ctx param in controller methods by @tariq1890 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/392&#xD;&#xA;* fix formatting by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/398&#xD;&#xA;* Update go to 1.19 by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/397&#xD;&#xA;* update cno and mco by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/396&#xD;&#xA;* Use ginkgo/v2 CLI --junit-report flag by @liornoy in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/395&#xD;&#xA;* Update GHW lib by @rollandf in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/400&#xD;&#xA;* Sort out binary installation in Makefile by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/399&#xD;&#xA;* Enable smfs flow steering by default in switchdev mode. by @wizhaoredhat in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/402&#xD;&#xA;* remove unused volume from sriov-device-plugin DS by @tariq1890 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/403&#xD;&#xA;* Make sriov-network-config-daemon crash when configmap cannot be obtained by @jkossak in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/391&#xD;&#xA;* Add support for operator deployment on PSA by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/371&#xD;&#xA;* Revert &#34;Add support for operator deployment on PSA&#34; by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/407&#xD;&#xA;* Update support for operator deployment on PSA by @SalDaniele in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/408&#xD;&#xA;* add printercolumn for syncStatus in SriovNetworkNodeState by @tariq1890 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/404&#xD;&#xA;* use openshift_context instead of internal function in util package by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/409&#xD;&#xA;* Deploy default SriovNetworkNodePolicy by helm chart by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/401&#xD;&#xA;* Vdpa introduction by @lmilleri in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/377&#xD;&#xA;* fix golangci lint config and goimports by @tariq1890 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/410&#xD;&#xA;* Fix networks-status annotation in e2e tests by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/413&#xD;&#xA;* Add the no-wait argument to ovs-vsctl commands for hw-offload by @wizhaoredhat in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/418&#xD;&#xA;* Skip the Redhat virtual nic from udev rule by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/405&#xD;&#xA;* stoping using beta.kubernetes.io/os by @pacoxu in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/411&#xD;&#xA;* Bump golang.org/x/net from 0.5.0 to 0.7.0 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/412&#xD;&#xA;* Make sriov-network-config-daemon crash when nodeInfo cannot be obtained by @lizhewei91 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/415&#xD;&#xA;* Pretty print CNI config when rendering NetAttachDefs by @tariq1890 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/406&#xD;&#xA;* improve the isdraning check for openshift by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/421&#xD;&#xA;* improve the isdraning check for openshift by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/419&#xD;&#xA;* Put sriov-network-config-daemon contianer on the first place by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/426&#xD;&#xA;* Add Intel x550 to supported NICs by @jjuele in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/425&#xD;&#xA;* Updating images to pull from github instead of quay.io by @Eoghan1232 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/424&#xD;&#xA;* Update NAD client by @rollandf in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/431&#xD;&#xA;* Replace go-restful lib version by @rollandf in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/433&#xD;&#xA;* Add NVIDIA BlueField 3 to supported NICs by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/437&#xD;&#xA;* Update base images to use CentOS 9 Stream by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/441&#xD;&#xA;* Add a costume junit reporter to the conformance suite by @liornoy in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/440&#xD;&#xA;* [Helm] Dont force deployment on control nodes by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/444&#xD;&#xA;* General cleanup in validate.go by @vrindle in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/422&#xD;&#xA;* Allow creating policies that ignore NUMA topology by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/435&#xD;&#xA;* small changes in e2e test to run on single node by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/446&#xD;&#xA;* Fix race condition in leader election for OCP by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/455&#xD;&#xA;* Add support for Intel X710 Backplane and Base T by @vrindle in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/452&#xD;&#xA;* Add sriovoperatorconfigs resource to webhook by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/461&#xD;&#xA;* Remove imagePullPolicy alltogether and use k8s defaults by @Longchuanzheng in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/432&#xD;&#xA;* Validate .Spec.DisableDrain by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/464&#xD;&#xA;* Implementation for new systemd configuration method by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/365&#xD;&#xA;* adding design template by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/470&#xD;&#xA;* Use `e2e-test` tag for images built in e2e CI by @abdallahyas in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/466&#xD;&#xA;* Re-introduce the check if the number of VFs is 0 by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/472&#xD;&#xA;* Fix issue 471 by @lmilleri in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/474&#xD;&#xA;* Improve operator logging by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/477&#xD;&#xA;* conformance-test: ExcludeTopology field by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/451&#xD;&#xA;* e2e: Fix Validate ExcludeTopology test leftover by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/482&#xD;&#xA;* Sync CRDs manifests by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/485&#xD;&#xA;* Avoid reconciling `SriovNetworkNodePolicies` multiple times by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/478&#xD;&#xA;* Reduce config-daemon logging verbosity by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/468&#xD;&#xA;* Render SriovNetworkNodeState before Device Plugin ConfigMap by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/487&#xD;&#xA;* Remove use of ioutil deprecated functions by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/491&#xD;&#xA;* Return reconcile error if node state is not updated by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/490&#xD;&#xA;* Never reduce MTU on PF by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/489&#xD;&#xA;* vhost-vdpa support by @lmilleri in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/467&#xD;&#xA;* Bump dependencies: K8S, controller-runtime and Go by @liornoy in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/495&#xD;&#xA;* config-daemon: Improve logging of draining state by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/494&#xD;&#xA;* Update device plugins volumes mounts by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/500&#xD;&#xA;* Update golang.org/x/net/html by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/499&#xD;&#xA;* Remove bundle since we use helm chart instead in upstream by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/502&#xD;&#xA;* Remove unused VERSION variable and accidentally added file by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/503&#xD;&#xA;* Utilize the k8s-reporter in the e2e tests by @liornoy in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/498&#xD;&#xA;* design doc for the externally-manage-pf support by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/476&#xD;&#xA;* SriovNetwork: react on namespace creation by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/493&#xD;&#xA;* Use the OPERATOR_NAMESPACE var in the k8sreporter by @liornoy in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/506&#xD;&#xA;* virtual cluster e2e tests changes by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/462&#xD;&#xA;* Fix Plugin Config Daemon node selector by @wizhaoredhat in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/484&#xD;&#xA;* Support Externally Created virtual functions by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/436&#xD;&#xA;* Add context to `validatePolicyForNodeState` errors by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/504&#xD;&#xA;* improve github actions by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/515&#xD;&#xA;* Add vlanProto parameter by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/517&#xD;&#xA;* Fix Config Daemon node selector by @wizhaoredhat in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/483&#xD;&#xA;* Kernel params set by the config daemon should be verified by @wizhaoredhat in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/486&#xD;&#xA;* Update error messages to show why no interface is selected by @vrindle in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/434&#xD;&#xA;* Refactor network controller namespace handlers by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/513&#xD;&#xA;* Add events for config daemon by @rollandf in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/519&#xD;&#xA;* Avoid recording multiple events by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/521&#xD;&#xA;* Fix operator deployment by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/525&#xD;&#xA;* Add support for Intel E823C NICs by @murali509 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/520&#xD;&#xA;* virtual: get real PCI address for each device found by @EmilienM in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/516&#xD;&#xA;* CI scripts improvements by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/523&#xD;&#xA;* webhook: Disable HTTP2 by default by @cgoncalves in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/522&#xD;&#xA;* Support loglevel and logfile for SR-IOV plugin by @andreaskaris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/509&#xD;&#xA;* conformance-test: Filter NIC by environment variable by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/514&#xD;&#xA;* Add SR-IOV Device Plugin CDI support by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/473&#xD;&#xA;* fix: sriov config service unit-file dependencies by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/532&#xD;&#xA;* Remove glog  by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/527&#xD;&#xA;* Support number of workers for the virtual cluster by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/528&#xD;&#xA;* Minor improvments for systemd mode implementation by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/531&#xD;&#xA;* e2e: Add `cluster-info` as job artifact by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/534&#xD;&#xA;* fix odd number of key-value in error logs by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/543&#xD;&#xA;* Fix equality comparison of policy specs by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/538&#xD;&#xA;* Increase end-to-end test coverage by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/529&#xD;&#xA;* Update controller-runtime to v0.16.3 by @cgoncalves in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/526&#xD;&#xA;* Logs `sriov-network-config-daemon` by default by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/545&#xD;&#xA;* Hash contents of cm instead of using resource version by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/549&#xD;&#xA;* Skip vf configuration when not found in VF group by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/539&#xD;&#xA;* Fix error overwrite for setSriovNumVfs by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/548&#xD;&#xA;* Add check to ensure jq can be found in $PATH when enabling switchdev mode by @vasrem in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/550&#xD;&#xA;* Reduce operator&#39;s controller logs via `OperatorConfig.LogLevel` by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/544&#xD;&#xA;* envtest: Stick to a specific setup-envtest version by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/551&#xD;&#xA;* Ignore nil objects occured when rendering a file by @vasrem in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/560&#xD;&#xA;* Fix number of args passed to log.Info by @mandre in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/562&#xD;&#xA;* Fix disable webhooks by default by @ianb-mp in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/557&#xD;&#xA;* image build target additions by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/563&#xD;&#xA;* Add more flexibility on how to configure certificates for the admission controllers via helm chart by @vasrem in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/561&#xD;&#xA;* e2e: Print involved devices by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/572&#xD;&#xA;* Change behavior when deleting default SriovNetworkNodePolicy and SriovOperatorConfig by @vasrem in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/566&#xD;&#xA;* Update chart README.md to reflect webhook changes by @vasrem in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/570&#xD;&#xA;* Update Helm chart kubeVersion check by @ianb-mp in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/576&#xD;&#xA;* Interface redesign by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/553&#xD;&#xA;* Use go-install-tool instead of go-get-tool for gomock by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/578&#xD;&#xA;* Externally managed fixes by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/567&#xD;&#xA;* Update golang to 1.21 by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/565&#xD;&#xA;* add design doc for switchdev mode refactoring by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/559&#xD;&#xA;* [switchdev 1/x] Add additional methods to host/kernel.go by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/582&#xD;&#xA;* Bump golang.org/x/crypto from 0.14.0 to 0.17.0 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/580&#xD;&#xA;* Bump google.golang.org/grpc from 1.54.0 to 1.56.3 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/579&#xD;&#xA;* Change layout of the pkg/host to simplify testing by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/586&#xD;&#xA;* [switchdev 2/x] API: Add vdpaType field to the node SriovNetworkNodeState CRD by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/583&#xD;&#xA;* CI: remove images after we push to cluster by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/589&#xD;&#xA;* [switchdev 3/x] Extend host pkg with required functions by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/588&#xD;&#xA;* fix k8s cluster script by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/593&#xD;&#xA;* Fix LogLevel functional test by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/591&#xD;&#xA;* fix ocp CI lane by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/595&#xD;&#xA;* e2e: Allow testing custom cni and dp image by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/518&#xD;&#xA;* re-enable mtu test on virtual cluster by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/594&#xD;&#xA;* Test fixes and enhancements by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/597&#xD;&#xA;* Refactor render of SR-IOV Device plugin by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/546&#xD;&#xA;* Use APITimeout and RetryInterval constant in tests by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/600&#xD;&#xA;* move namespace to vars pkg by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/601&#xD;&#xA;* Fix log messages in ReloadDriver &amp; GetOSPrettyName by @cgoncalves in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/603&#xD;&#xA;* Move default policy creation in controller tests to BeforeSuite. by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/604&#xD;&#xA;* Add wrapper for utils package from sriov-device-plugin by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/598&#xD;&#xA;* Cleanup Created object in controller tests by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/606&#xD;&#xA;* e2e: Skip tests when no VF-IO devices are available by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/596&#xD;&#xA;* Reduce timeout period in controller tests by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/607&#xD;&#xA;* Optimize a request to find device plugin pods. by @alan-kut in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/599&#xD;&#xA;* Add disable plugins by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/569&#xD;&#xA;* e2e: Fix `Debug logging should be visible in multus pod` flake by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/611&#xD;&#xA;* add w/a for multus bug in CI by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/612&#xD;&#xA;* Fix typo in mellanox plugin name in logs by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/615&#xD;&#xA;* Refactor controller tests by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/609&#xD;&#xA;* minor improvements in sriovOpeatorConfig controller by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/618&#xD;&#xA;* e2e: dump multus namespace by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/616&#xD;&#xA;* Set OwnerReference to sriov-device-plugin configmap by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/623&#xD;&#xA;* openstack: Fix `nil` HostManager in `openstackContext` by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/610&#xD;&#xA;* [switchdev 4/x] split systemd service to two parts by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/602&#xD;&#xA;* Add CI check to validate that go mods and vendor dir are in sync by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/627&#xD;&#xA;* Remove bool ptr by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/625&#xD;&#xA;* Parallel NICs configuration by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/497&#xD;&#xA;* Fix indentation for --parallel-nic-config flag in the daemon manifest by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/637&#xD;&#xA;* [Remove Default Objs  1/4] Dont create default SriovOperatorConfig by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/617&#xD;&#xA;* [switchdev 5/x] Add skipVFconfiguration option for generic_plugin by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/614&#xD;&#xA;* [Remove Default Objs  2/4] Set OwnerReference to `default` SriovOperatorConfig by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/621&#xD;&#xA;* e2e: Dump multus namespace on failures by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/636&#xD;&#xA;* Use default `{ib-}sriov-cni` entrypoint script by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/581&#xD;&#xA;* [Remove Default Objs  3/4] Remove default policy by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/622&#xD;&#xA;* [Remove Default Objs  4/4] Update Webhook by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/624&#xD;&#xA;* refactor: DiscoverSriovDevices imporvements by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/638&#xD;&#xA;* [switchdev 6/x] Update netlink lib and add helper functions by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/633&#xD;&#xA;* [switchdev 7/x] Add function EnableHwTcOffload to the network pkg by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/628&#xD;&#xA;* e2e: fix `CNI Logging level` test case by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/644&#xD;&#xA;* [switchdev 8/x] Add support for switchdev configuration to sriov pkg by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/642&#xD;&#xA;* Require reboot if drain is needed for systemd mode by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/645&#xD;&#xA;* Experiment: Remove stdin from the ExecCommand call in tests by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/650&#xD;&#xA;* Fix sriov.GetNicSriovMode to return legacy mode in case of any failure by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/647&#xD;&#xA;* Fix `IsKernelLockdownMode` by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/657&#xD;&#xA;* small security improvements by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/654&#xD;&#xA;* Add &#39;Parallel SR-IOV configuration&#39; design document by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/626&#xD;&#xA;* Parallel drain by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/555&#xD;&#xA;* Add multi-arch docker image support by @cyclinder in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/574&#xD;&#xA;* Bump google.golang.org/protobuf from 1.31.0 to 1.33.0 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/656&#xD;&#xA;* Set netdevice as default in the CRD by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/660&#xD;&#xA;* support switching resource injector webhook to Fail by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/658&#xD;&#xA;* Fix resource injector for pods wihtout annotation by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/664&#xD;&#xA;* Refactor SriovNetwork and SriovIBNetwork controllers to use same code by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/663&#xD;&#xA;* [switchdev 9/9] Enable new switchdev implementation by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/643&#xD;&#xA;* Add &#34;Software bridge management&#34; design doc by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/640&#xD;&#xA;* Add logic to deploy OVS-cni by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/648&#xD;&#xA;* Check for kernel lockdown only in mlx plugin by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/670&#xD;&#xA;* Add featuregate package and use it in controllers by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/673&#xD;&#xA;* Remove DPversion from nodeState by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/669&#xD;&#xA;* Fix configDaemonNodeSelector in SriovOperatorConfig in helm chart by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/677&#xD;&#xA;* Documentation update by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/674&#xD;&#xA;* Fix root device overlapping by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/671&#xD;&#xA;* Fix service CMD to return an error if device discovery failed by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/681&#xD;&#xA;* e2e: `Debug logging should be visible in multus pod` flake by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/678&#xD;&#xA;* Make OVS_CNI_IMAGE truly optional by @mandre in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/683&#xD;&#xA;* Fix config-daemon not waiting for drain to complete by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/682&#xD;&#xA;* Change system dependencies for &#34;post&#34; systemd service by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/680&#xD;&#xA;* add support to specifi cluster version for k8s CI by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/684&#xD;&#xA;* Allow switchdev+externallyManged configs in webhook by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/675&#xD;&#xA;* bump CNI version for the sriov-cni by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/665&#xD;&#xA;* Verify status changes on managed interfaces by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/530&#xD;&#xA;* Fix crash panic in operator when policy has empty node selector by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/679&#xD;&#xA;* Fix tests for API package by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/693&#xD;&#xA;* Bump controller-gen to v0.14.0 by @e0ne in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/692&#xD;&#xA;* Support adding or removing node by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/688&#xD;&#xA;* operator: LeaderElectionReleaseOnCancel  by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/556&#xD;&#xA;* Update Helm chart version by @Kristian-ZH in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/667&#xD;&#xA;* Bump golang.org/x/net from 0.17.0 to 0.23.0 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/685&#xD;&#xA;* don&#39;t reset the device plugin twice by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/695&#xD;&#xA;* Followup pr 646 by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/696&#xD;&#xA;* Use helm values to expand the supported NICs by @manuelbuil in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/698&#xD;&#xA;* [software-bridges 1/x] Update API to support automatic bridge creation by @ykulazhenkov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/689&#xD;&#xA;* Add more checks on generic plugin to discover discrepancies from the desired state by @vasrem in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/587&#xD;&#xA;* Update `config/` folder by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/705&#xD;&#xA;* Add &#39;IB VF GUID Configuration&#39; design doc by @almaslennikov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/653&#xD;&#xA;* Add mtu functional test by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/699&#xD;&#xA;* Fix issue preventing lowering of PF&#39;s MTU by @almaslennikov in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/700&#xD;&#xA;* Bump go version to 1.22 by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/712&#xD;&#xA;* Helm Chart release automation by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/706&#xD;&#xA;* Fix release chart update by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/714&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @eoghanlawless made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/340&#xD;&#xA;* @relyt0925 made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/332&#xD;&#xA;* @wizhaoredhat made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/358&#xD;&#xA;* @navadiaev made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/356&#xD;&#xA;* @pacevedom made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/363&#xD;&#xA;* @lgtm-com made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/375&#xD;&#xA;* @iancoolidge made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/389&#xD;&#xA;* @liornoy made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/386&#xD;&#xA;* @dependabot made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/394&#xD;&#xA;* @tariq1890 made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/392&#xD;&#xA;* @jkossak made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/391&#xD;&#xA;* @SalDaniele made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/408&#xD;&#xA;* @lmilleri made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/377&#xD;&#xA;* @pacoxu made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/411&#xD;&#xA;* @lizhewei91 made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/415&#xD;&#xA;* @jjuele made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/425&#xD;&#xA;* @Eoghan1232 made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/424&#xD;&#xA;* @mlguerrero12 made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/461&#xD;&#xA;* @Longchuanzheng made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/432&#xD;&#xA;* @murali509 made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/520&#xD;&#xA;* @cgoncalves made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/522&#xD;&#xA;* @vasrem made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/550&#xD;&#xA;* @mandre made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/562&#xD;&#xA;* @ianb-mp made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/557&#xD;&#xA;* @alan-kut made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/599&#xD;&#xA;* @cyclinder made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/574&#xD;&#xA;* @Kristian-ZH made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/667&#xD;&#xA;* @almaslennikov made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/653&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/k8snetworkplumbingwg/sriov-network-operator/compare/v1.2.0...v1.3.0</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

