### PR TITLE
Add multi-stage Dockerfile target

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -48,6 +48,7 @@ jobs:
         context: .
         push: true
         tags: rancher/hardened-sriov-network-operator:${{ github.event.release.tag_name }}
+        target: operator
         file: Dockerfile
         platforms: linux/amd64, linux/arm64
         build-args: |
@@ -59,6 +60,7 @@ jobs:
         context: .
         push: true
         tags: rancher/hardened-sriov-network-config-daemon:${{ github.event.release.tag_name }}
+        target: config-daemon
         file: Dockerfile
         platforms: linux/amd64, linux/arm64
         build-args: |
@@ -70,6 +72,7 @@ jobs:
         context: .
         push: true
         tags: rancher/hardened-sriov-network-webhook:${{ github.event.release.tag_name }}
+        target: webhook
         file: Dockerfile
         platforms: linux/amd64, linux/arm64
         build-args: |


### PR DESCRIPTION
The image push action publishes the following images:
- `rancher/hardened-sriov-network-operator`
- `rancher/hardened-sriov-network-config-daemon`
- `rancher/hardened-sriov-network-webhook`

On release these are built as an `operator` image when instead they
need to be built using their own respective image stage targets

Fixup for 1e9cd69fc4249bf3d05cd3ee76951ebe6d29470e
Signed-off-by: Michael Fritch <mfritch@suse.com>